### PR TITLE
use ansible-scan-core and remove dependency on ARI

### DIFF
--- a/ansible_gatekeeper/utils.py
+++ b/ansible_gatekeeper/utils.py
@@ -106,9 +106,9 @@ def get_module_name_from_task(task):
         module_name = task.module_info.get("fqcn", "")
     if task.annotations:
         if not module_name:
-            module_name = task.annotations.get("module.correct_fqcn", "")
+            module_name = task.get_annotation("module.correct_fqcn", "")
         if not module_name:
-            module_name = task.annotations.get("correct_fqcn", "")
+            module_name = task.get_annotation("correct_fqcn", "")
 
     if not module_name:
         module_name = task.module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "sage-scan@git+https://github.com/IBM/sage",
-
-    # install sage-proecss manually
-    # "sage-process@git+https://github.ibm.com/ansible-risk-insight/sage-process",
-
-    # install pb-refine manually
-    # "pb-refine@git+https://github.ibm.com/ansible-risk-insight/pb-refine",
-
+    "ansible-scan-core@git+https://github.com/ansible/ansible-scan-core",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- Now ansible-gatekeeper depends on ansible-scan-core as the core library of scanning function, remove dependency on ansible-risk-insight