### PR TITLE
error when using os.get_terminal_size in sub proccess

### DIFF
--- a/ansible_gatekeeper/models.py
+++ b/ansible_gatekeeper/models.py
@@ -4,6 +4,7 @@ import re
 import glob
 import tempfile
 import jsonpickle
+import shutil
 from dataclasses import dataclass, field
 from typing import List, Union
 from ansible.executor.task_result import TaskResult
@@ -720,7 +721,7 @@ class ResultFormatter(object):
         if self.isatty is None:
             self.isatty = sys.stdout.isatty()
         if self.term_width is None:
-            self.term_width = os.get_terminal_size().columns
+            self.term_width = shutil.get_terminal_size().columns
         return
 
     def print(self, result: EvaluationResult):


### PR DESCRIPTION
after the latest (yesterday) changes os.get_terminal_size  is failing when used in a subprocess

```bash
stderr: b'Traceback (most recent call last):\n  File "<frozen runpy>", line 198, in _run_module_as_main\n  File "<frozen runpy>", line 88, in _run_code\n  File "/home/ec2-user/.venv/lib64/python3.11/site-packages/ansible_gatekeeper/eval_policy.py", line 74, in <module>\n    main()\n  File "/home/ec2-user/.venv/lib64/python3.11/site-packages/ansible_gatekeeper/eval_policy.py", line 70, in main\n    ResultFormatter(format_type=args.format).print(result=result)\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "<string>", line 6, in __init__\n  File "/home/ec2-user/.venv/lib64/python3.11/site-packages/ansible_gatekeeper/models.py", line 723, in __post_init__\n    self.term_width = os.get_terminal_size().columns\n                      ^^^^^^^^^^^^^^^^^^^^^^\nOSError: [Errno 25] Inappropriate ioctl for device\n'
```

using shutil high level [shutil.get_terminal_size()](https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size)
resolve the problem 

![image](https://github.com/ansible/ansible-gatekeeper/assets/131553/b0e907c9-6d09-44a4-a3a7-41a6442f728b)

