### PR TITLE
fix transpiler to allow use of '?' in name field

### DIFF
--- a/ansible_policy/policybook/condition_parser.py
+++ b/ansible_policy/policybook/condition_parser.py
@@ -119,7 +119,7 @@ null_t = Literal("null").copy().add_parse_action(lambda toks: Null())
 #     QuotedString('"').copy().add_parse_action(lambda toks: String(toks[0]))
 # )
 
-plain_string = Word(alphanums + "[" + "]" + "." + "_" + "'" + '"').copy().add_parse_action(lambda toks: String(toks[0]))
+plain_string = Word(alphanums + "[" + "]" + "." + "_" + "'" + '"' + ",").copy().add_parse_action(lambda toks: String(toks[0]))
 
 # allowed_values = number_t | boolean | null_t | string1 | string2
 allowed_values = number_t | boolean | null_t
@@ -301,6 +301,8 @@ condition = infix_notation(
 
 def parse_condition(condition_string: str) -> Condition:
     condition.debug = True
+    # !! short term solution to support list format like ["A", "B", "C"] in condition
+    condition_string = condition_string.replace(", ", ",")
     condition.parseString(condition_string, parse_all=True)[0]
     try:
         return condition.parseString(condition_string, parse_all=True)[0]

--- a/ansible_policy/policybook/transpiler.py
+++ b/ansible_policy/policybook/transpiler.py
@@ -110,7 +110,7 @@ class PolicyTranspiler:
             # package
             _package = pol["name"]
             if " " in pol["name"]:
-                _package = pol["name"].replace(" ", "_").replace("-", "_")
+                _package = pol["name"].replace(" ", "_").replace("-", "_").replace("?", "")
             rego_policy.package = _package
             # import statements
             rego_policy.import_statements = [
@@ -209,7 +209,7 @@ class PolicyTranspiler:
         rf = RegoFunc()
         func_name = f"{policy_name}_{index}"
         if " " in func_name:
-            func_name = func_name.replace(" ", "_").replace("-", "_")
+            func_name = func_name.replace(" ", "_").replace("-", "_").replace("?", "")
         rf.name = func_name
         if "AndExpression" in condition:
             rego_expressions = []


### PR DESCRIPTION
Signed-off-by: Ruriko Kudo <rurikudo@ibm.com>

- fix transpiler to allow use of `?` in name field
- fix policybook parser to allow use of list in condition field