### PR TITLE
add new operators and actions

### DIFF
--- a/ansible_policy/policybook/condition_parser.py
+++ b/ansible_policy/policybook/condition_parser.py
@@ -275,17 +275,31 @@ def parse_condition(condition_string: str) -> Condition:
 
 def main():
     test_condition_strings = [
+        # not in
         'input["ansible.builtin.package"].name not in allowed_packages',
+        # nested list
         'input["ansible.builtin.package"].name not in [[input["amazon.aws"], "A2"], "B", "C"]',
+        # in
         'input["ansible.builtin.package"].name in input["ansible.builtin.package"].alist',
+        # bool, multi_cond
         '"input.become == true and input.become_user not in allowed_users"',
+        # lacks key
         '"input.become == true and input lacks key become_user"',
+        # input._agk.xxx
         '"input._agk.task.module_info.collection not in allowed_collections"',
+        # input["xxx"]
         'input["ansible.posix.firewalld"].service in banned_services',
-        'input["amazon.aws.rds_instance"].publicly_accessible == true',
+        # "-"
         'input.become == true and input.become_user != "malicious-user"',
         'input["ansible.builtin.lineinfile"].line != \'DOCKER_OPTS="--dns"\'',
-        'input["cisco.ios.ios_config"].lines in banned_configurations.telnet',
+        # "*"
+        'input.become == true and input.become_user != "*"',
+        # "+"
+        'input["ansible.builtin.package"].name != "package++"',
+        # is not defined
+        'input["kubernetes.core.k8s"].kubeconfig is not defined',
+        # defined
+        'input["kubernetes.core.k8s"].kubeconfig is defined',
     ]
 
     for s in test_condition_strings:

--- a/ansible_policy/policybook/condition_parser.py
+++ b/ansible_policy/policybook/condition_parser.py
@@ -27,8 +27,9 @@ from pyparsing import (
     Suppress,
     Word,
     ZeroOrMore,
+    DelimitedList,
+    Forward,
     alphanums,
-    delimitedList,
     infix_notation,
     one_of,
     originalTextFor,
@@ -94,7 +95,7 @@ logger = logging.getLogger(__name__)
 number_t = pyparsing_common.number.copy().add_parse_action(lambda toks: to_condition_type(toks[0]))
 
 ident = pyparsing_common.identifier
-valid_prefix = Keyword("events") | Keyword("event") | Keyword("facts") | Keyword("vars") | Keyword("fact")
+valid_prefix = Keyword("input")
 varname = (
     Combine(
         valid_prefix
@@ -112,35 +113,27 @@ boolean = (true | false).copy().add_parse_action(lambda toks: Boolean(toks[0].lo
 
 null_t = Literal("null").copy().add_parse_action(lambda toks: Null())
 
-# string1 = (
-#     QuotedString("'").copy().add_parse_action(lambda toks: String(toks[0]))
-# )
-# string2 = (
-#     QuotedString('"').copy().add_parse_action(lambda toks: String(toks[0]))
-# )
+string1 = QuotedString("'").copy().add_parse_action(lambda toks: String(toks[0]))
+string2 = QuotedString('"').copy().add_parse_action(lambda toks: String(toks[0]))
 
-plain_string = Word(alphanums + "[" + "]" + "." + "_" + "'" + '"' + ",").copy().add_parse_action(lambda toks: String(toks[0]))
-
-# allowed_values = number_t | boolean | null_t | string1 | string2
-allowed_values = number_t | boolean | null_t
+plain_string = Word(alphanums + "_" + ".").copy().add_parse_action(lambda toks: String(toks[0]))
+allowed_values = number_t | boolean | null_t | string1 | string2
 key_value = ident + Suppress("=") + allowed_values
 string_search_t = (
-    one_of("regex match search")
-    + Suppress("(")
-    # + Group(Optional(delimitedList(string1 | string2 | varname | key_value)))
-    + Group(Optional(delimitedList(varname | key_value)))
-    + Suppress(")")
+    one_of("regex match search") + Suppress("(") + Group(Optional(DelimitedList(string1 | string2 | varname | key_value))) + Suppress(")")
 )
 
-delim_value = Group(
-    # delimitedList(number_t | null_t | boolean | varname | string1 | string2)
-    delimitedList(number_t | null_t | boolean | varname)
-)
-list_values = Suppress("[") + delim_value + Suppress("]")
+list_values = Forward()
 
-selectattr_t = Literal("selectattr") + Suppress("(") + Group(delimitedList(allowed_values | list_values | varname)) + Suppress(")")
+allowed_values = number_t | boolean | null_t | string1 | string2
 
-select_t = Literal("select") + Suppress("(") + Group(delimitedList(allowed_values | list_values | varname)) + Suppress(")")
+delim_value = Group(DelimitedList(number_t | null_t | boolean | varname | string1 | string2 | list_values))
+
+list_values <<= Suppress("[") + delim_value + Suppress("]")
+
+selectattr_t = Literal("selectattr") + Suppress("(") + Group(DelimitedList(allowed_values | list_values | varname)) + Suppress(")")
+
+select_t = Literal("select") + Suppress("(") + Group(DelimitedList(allowed_values | list_values | varname)) + Suppress(")")
 
 
 def as_list(var):
@@ -198,34 +191,10 @@ def OperatorExpressionFactory(tokens):
     return return_value
 
 
-all_terms = (
-    selectattr_t
-    | select_t
-    | string_search_t
-    | list_values
-    | number_t
-    | null_t
-    | boolean
-    | varname
-    | plain_string
-    # | string1
-    # | string2
-)
+all_terms = selectattr_t | select_t | string_search_t | list_values | number_t | null_t | boolean | varname | plain_string | string1 | string2
 condition = infix_notation(
-    all_terms,
-    [
-        (
-            one_of("* /"),
-            2,
-            OpAssoc.LEFT,
-            lambda toks: OperatorExpressionFactory(toks[0]),
-        ),
-        (
-            one_of("+ -"),
-            2,
-            OpAssoc.LEFT,
-            lambda toks: OperatorExpressionFactory(toks[0]),
-        ),
+    base_expr=all_terms,
+    op_list=[
         (
             ">=",
             2,
@@ -289,20 +258,12 @@ condition = infix_notation(
             OpAssoc.LEFT,
             lambda toks: OperatorExpressionFactory(toks[0]),
         ),
-        (
-            "<<",
-            2,
-            OpAssoc.LEFT,
-            lambda toks: OperatorExpressionFactory(toks[0]),
-        ),
     ],
 ).add_parse_action(lambda toks: Condition(toks[0]))
 
 
 def parse_condition(condition_string: str) -> Condition:
     condition.debug = True
-    # !! short term solution to support list format like ["A", "B", "C"] in condition
-    condition_string = condition_string.replace(", ", ",")
     condition.parseString(condition_string, parse_all=True)[0]
     try:
         return condition.parseString(condition_string, parse_all=True)[0]
@@ -310,3 +271,28 @@ def parse_condition(condition_string: str) -> Condition:
         msg = f"Error parsing: {condition_string}. {pe}"
         logger.debug(pe.explain(depth=0))
         raise ConditionParsingException(msg)
+
+
+def main():
+    test_condition_strings = [
+        'input["ansible.builtin.package"].name not in allowed_packages',
+        'input["ansible.builtin.package"].name not in [[input["amazon.aws"], "A2"], "B", "C"]',
+        'input["ansible.builtin.package"].name in input["ansible.builtin.package"].alist',
+        '"input.become == true and input.become_user not in allowed_users"',
+        '"input.become == true and input lacks key become_user"',
+        '"input._agk.task.module_info.collection not in allowed_collections"',
+        'input["ansible.posix.firewalld"].service in banned_services',
+        'input["amazon.aws.rds_instance"].publicly_accessible == true',
+        'input.become == true and input.become_user != "malicious-user"',
+        'input["ansible.builtin.lineinfile"].line != \'DOCKER_OPTS="--dns"\'',
+        'input["cisco.ios.ios_config"].lines in banned_configurations.telnet',
+    ]
+
+    for s in test_condition_strings:
+        print(f"condition string: \n{s}\n")
+        r = parse_condition(s)
+        print(f"parse result:\n{r}\n\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_policy/policybook/json_generator.py
+++ b/ansible_policy/policybook/json_generator.py
@@ -59,6 +59,8 @@ OPERATOR_MNEMONIC = {
     "not contains": "ListNotContainsItemExpression",
     "has key": "KeyInDictExpression",
     "lacks key": "KeyNotInDictExpression",
+    "is not defined": "IsNotDefinedExpression",
+    "is defined": "IsDefinedExpression",
 }
 
 

--- a/ansible_policy/policybook/json_generator.py
+++ b/ansible_policy/policybook/json_generator.py
@@ -53,9 +53,6 @@ OPERATOR_MNEMONIC = {
     "<": "LessThanExpression",
     ">=": "GreaterThanOrEqualToExpression",
     "<=": "LessThanOrEqualToExpression",
-    "+": "AdditionExpression",
-    "-": "SubtractionExpression",
-    "<<": "AssignmentExpression",
     "in": "ItemInListExpression",
     "not in": "ItemNotInListExpression",
     "contains": "ListContainsItemExpression",
@@ -74,20 +71,10 @@ def visit_condition(parsed_condition: ConditionTypes):
     elif isinstance(parsed_condition, Boolean):
         return {"Boolean": True} if parsed_condition.value == "true" else {"Boolean": False}
     elif isinstance(parsed_condition, Identifier):
-        if parsed_condition.value.startswith("fact."):
-            return {"Fact": parsed_condition.value[5:]}
-        elif parsed_condition.value.startswith("fact["):
-            return {"Fact": parsed_condition.value[4:]}
-        elif parsed_condition.value.startswith("event."):
-            return {"Event": parsed_condition.value[6:]}
-        elif parsed_condition.value.startswith("event["):
-            return {"Event": parsed_condition.value[5:]}
-        elif parsed_condition.value.startswith("events."):
-            return {"Events": parsed_condition.value[7:]}
-        elif parsed_condition.value.startswith("facts."):
-            return {"Facts": parsed_condition.value[6:]}
+        if parsed_condition.value.startswith("input"):
+            return {"Input": parsed_condition.value}
         else:
-            msg = f"Invalid identifier : {parsed_condition.value} " + "Should start with event., events.,fact., facts. or vars."
+            msg = f"Invalid identifier : {parsed_condition.value} " + "Should start with input."
             raise InvalidIdentifierException(msg)
 
     elif isinstance(parsed_condition, String):

--- a/ansible_policy/policybook/policy_parser.py
+++ b/ansible_policy/policybook/policy_parser.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, List
 import ansible_policy.policybook.policybook_models as pm
 from ansible_policy.policybook.condition_parser import parse_condition as parse_condition_value
 
+VALID_ACTIONS = ["allow", "deny", "info", "warn", "ignore"]
+
 
 def parse_hosts(hosts):
     if isinstance(hosts, str):
@@ -120,6 +122,8 @@ def parse_actions(rule: Dict) -> List[pm.Action]:
 
 def parse_action(action: Dict) -> pm.Action:
     action_name = list(action.keys())[0]
+    if action_name not in VALID_ACTIONS:
+        raise Exception(f"Unsupported action {action_name}. supported actions are {VALID_ACTIONS}")
     if action[action_name]:
         action_args = {k: v for k, v in action[action_name].items()}
     else:

--- a/ansible_policy/policybook/rego_templates.py
+++ b/ansible_policy/policybook/rego_templates.py
@@ -1,14 +1,8 @@
 import string
 
 # action func
-deny = """
-deny = true if {
-    ${steps}
-} else = false
-"""
-
-allow = """
-allow = true if {
+action_func = """
+${func_name} = true if {
     ${steps}
 } else = false
 """
@@ -76,8 +70,7 @@ class TemplateManager:
     def __init__(self):
         self.templates = {}
         # action func
-        self._deny_func = self.add_template(deny)
-        self._allow_func = self.add_template(allow)
+        self._action_func = self.add_template(action_func)
         # condition func
         self._if_func = self.add_template(if_func)
         # operation

--- a/ansible_policy/policybook/rego_templates.py
+++ b/ansible_policy/policybook/rego_templates.py
@@ -34,6 +34,16 @@ key_not_in_dict_condition = """${lhs}
     input_keys := [key | ${lhs}[key]; key == ${rhs}]
     count(input_keys) == 0"""
 
+args_is_not_defined_condition = """${val1}
+    not ${val2}"""
+
+args_is_defined_condition = """${val1}
+    ${val2}"""
+
+var_is_not_defined_condition = """not ${val1}"""
+
+var_is_defined_condition = """${val1}"""
+
 # rego util funcs
 item_not_in_list_func = """
 check_item_not_in_list(lhs_list, rhs_list) = true if {
@@ -75,6 +85,10 @@ class TemplateManager:
         self._item_in_list_expression = self.add_template(item_in_list_condition)
         self._key_in_dict_expression = self.add_template(key_in_dict_condition)
         self._key_not_in_dict_expression = self.add_template(key_not_in_dict_condition)
+        self._args_is_not_defined_expression = self.add_template(args_is_not_defined_condition)
+        self._args_is_defined_expression = self.add_template(args_is_defined_condition)
+        self._var_is_not_defined_expression = self.add_template(var_is_not_defined_condition)
+        self._var_is_defined_expression = self.add_template(var_is_defined_condition)
         # util funcs
         self._item_not_in_list_func = item_not_in_list_func
         self._item_in_list_func = item_in_list_func

--- a/ansible_policy/policybook/transpiler.py
+++ b/ansible_policy/policybook/transpiler.py
@@ -20,6 +20,7 @@ import argparse
 import os
 import glob
 import re
+import json
 from ansible_policy.policybook.rego_templates import TemplateManager
 from ansible_policy.policybook.json_generator import OPERATOR_MNEMONIC
 from ansible_policy.policybook.json_generator import generate_dict_policysets
@@ -109,8 +110,7 @@ class PolicyTranspiler:
             rego_policy = RegoPolicy()
             # package
             _package = pol["name"]
-            if " " in pol["name"]:
-                _package = pol["name"].replace(" ", "_").replace("-", "_").replace("?", "")
+            _package = self.clean_error_token(pol["name"])
             rego_policy.package = _package
             # import statements
             rego_policy.import_statements = [
@@ -194,12 +194,15 @@ class PolicyTranspiler:
     def make_rego_print(self, input_text):
         pattern = r"{{\s*([^}]+)\s*}}"
         replacement = r"%v"
-
+        # replace vars part to rego style
         result = re.sub(pattern, replacement, input_text)
         vals = re.findall(pattern, input_text)
         if len(vals) != 0:
-            vals = [v.strip() for v in vals]
+            # Strip whitespace from all string values in the list
+            vals = [v.strip() if isinstance(v, str) else v for v in vals]
             val_str = ", ".join(vals)
+            # replace " with '
+            result = result.replace('"', "'")
             return f'print(sprintf("{result}", [{val_str}]))'
         else:
             return f'print("{input_text}")'
@@ -208,8 +211,7 @@ class PolicyTranspiler:
     def convert_condition_func(self, condition: dict, policy_name: str, index: int = 0):
         rf = RegoFunc()
         func_name = f"{policy_name}_{index}"
-        if " " in func_name:
-            func_name = func_name.replace(" ", "_").replace("-", "_").replace("?", "")
+        func_name = self.clean_error_token(func_name)
         rf.name = func_name
         if "AndExpression" in condition:
             rego_expressions = []
@@ -241,7 +243,7 @@ class PolicyTranspiler:
         util_funcs = []
         if "EqualsExpression" in ast_exp:
             lhs = ast_exp["EqualsExpression"]["lhs"]
-            lhs_val = list(lhs.values())[0]
+            lhs_val = self.change_data_format(lhs)
             rhs = ast_exp["EqualsExpression"]["rhs"]
             for type, val in rhs.items():
                 if type == "String":
@@ -251,7 +253,7 @@ class PolicyTranspiler:
                     rego_expressions.append(f"{lhs_val}")
         elif "NotEqualsExpression" in ast_exp:
             lhs = ast_exp["NotEqualsExpression"]["lhs"]
-            lhs_val = list(lhs.values())[0]
+            lhs_val = self.change_data_format(lhs)
             rhs = ast_exp["NotEqualsExpression"]["rhs"]
             for type, val in rhs.items():
                 if type == "String":
@@ -262,17 +264,17 @@ class PolicyTranspiler:
                     rego_expressions.append(f"not {lhs_val}")
         elif "ItemNotInListExpression" in ast_exp:
             lhs = ast_exp["ItemNotInListExpression"]["lhs"]
-            lhs_val = list(lhs.values())[0]
+            lhs_val = self.change_data_format(lhs)
             rhs = ast_exp["ItemNotInListExpression"]["rhs"]
-            rhs_val = list(rhs.values())[0]
+            rhs_val = self.change_data_format(rhs)
             template = rego_tpl._item_not_in_list_expression
             util_funcs = [rego_tpl._to_list_func, rego_tpl._item_not_in_list_func]
             rego_expressions.append(self.make_expression_from_val(template, lhs=lhs_val, rhs=rhs_val))
         elif "ItemInListExpression" in ast_exp:
             lhs = ast_exp["ItemInListExpression"]["lhs"]
-            lhs_val = list(lhs.values())[0]
+            lhs_val = self.change_data_format(lhs)
             rhs = ast_exp["ItemInListExpression"]["rhs"]
-            rhs_val = list(rhs.values())[0]
+            rhs_val = self.change_data_format(rhs)
             template = rego_tpl._item_in_list_expression
             util_funcs = [rego_tpl._to_list_func, rego_tpl._item_in_list_func]
             rego_expressions.append(self.make_expression_from_val(template, lhs=lhs_val, rhs=rhs_val))
@@ -280,32 +282,32 @@ class PolicyTranspiler:
             # ListContainsItemExpression is basically the same as ItemInListExpression
             #   except for the difference in the position of the lhs and rhs values.
             lhs = ast_exp["ListContainsItemExpression"]["lhs"]
-            lhs_val = list(lhs.values())[0]
+            lhs_val = self.change_data_format(lhs)
             rhs = ast_exp["ListContainsItemExpression"]["rhs"]
-            rhs_val = list(rhs.values())[0]
+            rhs_val = self.change_data_format(rhs)
             template = rego_tpl._item_in_list_expression
             util_funcs = [rego_tpl._to_list_func, rego_tpl._item_in_list_func]
             rego_expressions.append(self.make_expression_from_val(template, lhs=rhs_val, rhs=lhs_val))
         elif "ListNotContainsItemExpression" in ast_exp:
             lhs = ast_exp["ItemNotInListExpression"]["lhs"]
-            lhs_val = list(lhs.values())[0]
+            lhs_val = self.change_data_format(lhs)
             rhs = ast_exp["ItemNotInListExpression"]["rhs"]
-            rhs_val = list(rhs.values())[0]
+            rhs_val = self.change_data_format(rhs)
             template = rego_tpl._item_not_in_list_expression
             util_funcs = [rego_tpl._to_list_func, rego_tpl._item_not_in_list_func]
             rego_expressions.append(self.make_expression_from_val(template, lhs=rhs_val, rhs=lhs_val))
         elif "KeyInDictExpression" in ast_exp:
             lhs = ast_exp["KeyInDictExpression"]["lhs"]
-            lhs_val = list(lhs.values())[0]
+            lhs_val = self.change_data_format(lhs)
             rhs = ast_exp["KeyInDictExpression"]["rhs"]
-            rhs_val = list(rhs.values())[0].replace('"', "")
+            rhs_val = self.change_data_format(rhs).replace('"', "")
             template = rego_tpl._key_in_dict_expression
             rego_expressions.append(self.make_expression_from_val(template, lhs=lhs_val, rhs=f'"{rhs_val}"'))
         elif "KeyNotInDictExpression" in ast_exp:
             lhs = ast_exp["KeyNotInDictExpression"]["lhs"]
-            lhs_val = list(lhs.values())[0]
+            lhs_val = self.change_data_format(lhs)
             rhs = ast_exp["KeyNotInDictExpression"]["rhs"]
-            rhs_val = list(rhs.values())[0].replace('"', "")
+            rhs_val = self.change_data_format(rhs).replace('"', "")
             template = rego_tpl._key_not_in_dict_expression
             rego_expressions.append(self.make_expression_from_val(template, lhs=lhs_val, rhs=f'"{rhs_val}"'))
         # elif "GreaterThanExpression" in ast_exp:
@@ -323,6 +325,18 @@ class PolicyTranspiler:
         # elif "AssignmentExpression" in ast_exp:
         #     TODO: implementation
         return rego_expressions, util_funcs
+
+    def change_data_format(self, data):
+        if isinstance(data, list):
+            return json.dumps([self.change_data_format(item) for item in data])
+        elif isinstance(data, dict) and "String" in data:
+            return data["String"]
+        elif isinstance(data, dict) and "Input" in data:
+            return data["Input"]
+        elif isinstance(data, dict) and "Boolean" in data:
+            return data["Boolean"]
+        else:
+            return data
 
     def has_expression(self, data):
         keys = data.keys()
@@ -353,6 +367,9 @@ class PolicyTranspiler:
         elif isinstance(str_or_list, list):
             value = separator.join(str_or_list)
         return value
+
+    def clean_error_token(self, in_str):
+        return in_str.replace(" ", "_").replace("-", "_").replace("?", "").replace("(", "_").replace(")", "_")
 
 
 def load_file(input):


### PR DESCRIPTION
Signed-off-by: Ruriko Kudo <rurikudo@ibm.com>

- support `is defined` and `is not defined` operator
- support `ignore`, `warn` and `info` actions in transpiler
- fix policybook parser