### PR TITLE
use command -v instead of which for check command installation 

### DIFF
--- a/ansible_policy/utils.py
+++ b/ansible_policy/utils.py
@@ -33,7 +33,7 @@ logger = init_logger(__name__, os.getenv("ANSIBLE_GK_LOG_LEVEL", "info"))
 
 def validate_opa_installation(executable_name: str = "opa"):
     proc = subprocess.run(
-        f"which {executable_name}",
+        f"command -v {executable_name}",
         shell=True,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

Use `command -v` instead of `which` to check if `opa` command is installed or not, because `which` is not built-in on some Linux flavors (e.g. CentOS).

Related issue: https://github.com/ansible/ansible-policy/issues/53