### PR TITLE
update utils.rego to be compatible with opa v1

### DIFF
--- a/ansible_policy/rego/utils.rego
+++ b/ansible_policy/rego/utils.rego
@@ -5,22 +5,22 @@ package ansible_policy
 import future.keywords.if
 
 
-has_key(x, key) { _ = x[key] }
+has_key(x, key) if { _ = x[key] }
 
 # trial1: when task.module is FQCN
-get_module_fqcn(task) := fqcn {
+get_module_fqcn(task) := fqcn if {
     has_key(data.galaxy.modules, task.module)
     fqcn := data.galaxy.modules[task.module].fqcn
 }
 
 # trial2: when task.module is a valid short name
-get_module_fqcn(task) := fqcn {
+get_module_fqcn(task) := fqcn if {
     not has_key(data.galaxy.modules, task.module)
     has_key(data.galaxy.module_name_mappings, task.module)
     fqcn := data.galaxy.module_name_mappings[task.module][0]
 }
 
-request_http_data_source(url) := ext_data {
+request_http_data_source(url) := ext_data if {
     resp := http.send({
         "method": "get",
         "headers": {
@@ -31,14 +31,14 @@ request_http_data_source(url) := ext_data {
     ext_data := resp.body
 }
 
-_find_playbook_by_task(task) := playbook_key {
+_find_playbook_by_task(task) := playbook_key if {
     playbook := input._agk.playbooks[_]
     current_task = playbook.tasks[_]
     current_task.key == task.key
     playbook_key := playbook.key
 }
 
-_find_taskfile_by_task(task) := taskfile_key {
+_find_taskfile_by_task(task) := taskfile_key if {
     taskfile := input._agk.taskfiles[_]
     current_task = taskfile.tasks[_]
     current_task.key == task.key
@@ -55,7 +55,7 @@ _find_entrypoint_by_task(task) := taskfile_key if {
     taskfile_key
 }
 
-resolve_var(ref, task) := var_value {
+resolve_var(ref, task) := var_value if {
     var_name_tmp1 := replace(ref, "{{", "")
     var_name_tmp2 := replace(var_name_tmp1, "}}", "")
     var_name := replace(var_name_tmp2, " ", "")


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- Update the Rego helper (utils.rego) to be compatible with OPA v1.x style.

Related Issue: https://github.com/ansible/ansible-policy/issues/56